### PR TITLE
Add Java app with CI/CD incorporating Cloud Deploy

### DIFF
--- a/application/java-app-cicd/Dockerfile
+++ b/application/java-app-cicd/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM eclipse-temurin:20-alpine
+ARG JAR_FILE=SPECIFIED_AS_BUILD_ARG
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/application/java-app-cicd/README.md
+++ b/application/java-app-cicd/README.md
@@ -1,0 +1,5 @@
+# Java App
+
+```
+gcloud builds submit --region=us-central1 --substitutions _REPO_NAME=cp-repo,_APP_NAME=helloworld
+```

--- a/application/java-app-cicd/build/cloudbuild.yaml
+++ b/application/java-app-cicd/build/cloudbuild.yaml
@@ -1,0 +1,68 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - '-c'
+      - |
+        IFS='/' read -a array <<< "${_REF}"
+        echo ${_REF}
+        echo 0 ${array[0]}
+        echo 1 ${array[1]}
+        echo 2 ${array[2]}
+        echo REPO=${_APP_REPO}
+        echo _SHA=${_SHA}
+        export REPO=${_APP_REPO}
+
+        echo BRANCH_NAME=${array[2]}
+        export BRANCH_NAME=${array[2]}
+
+        if ((${array[1]} == "tags")); then
+          echo "TAG " ${BRANCH_NAME}
+        elif ((${array[2]} == "main")); then
+          echo "main"
+        else
+          echo ${BRANCH_NAME}
+        fi
+        echo "git clone -b ${array[2]} ${_APP_REPO}"
+        git clone -b ${array[2]} ${_APP_REPO}
+        echo done
+    id: clone-app
+    entrypoint: bash
+  - name: maven:3-eclipse-temurin-20-alpine
+    entrypoint: mvn
+    args: ["test", "--file", "./$_APP_ID/pom.xml"]
+  - name: maven:3-eclipse-temurin-20-alpine
+    entrypoint: mvn
+    args: ["package", "-Dmaven.test.skip", "--file", "./$_APP_ID/pom.xml"]
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "$_REGION-docker.pkg.dev/$PROJECT_ID/cp-repo/$_APP_ID", "--build-arg=JAR_FILE=target/helloworld-1.0.0.jar", "./$_APP_ID"]
+  - name: gcr.io/cloud-builders/docker
+    args: ['push', '$_REGION-docker.pkg.dev/$PROJECT_ID/cp-repo/$_APP_ID']
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: 'bash'
+    args:
+    - '-xe'
+    - -c
+    - |
+      IMG_SHA=$(gcloud artifacts docker images describe $_REGION-docker.pkg.dev/$PROJECT_ID/cp-repo/$_APP_ID:latest --format='value(image_summary.digest)')
+      SHA_COPY=${_SHA:7}
+      RELEASE_NAME=$_APP_ID-${SHA_COPY:-$(date '+%Y%m%d%H%M%S')}
+      cd $_APP_ID && gcloud deploy releases create \
+      --delivery-pipeline=$_APP_ID-pipeline \
+      --region=$_REGION \
+      --images=helloworld=$_REGION-docker.pkg.dev/$PROJECT_ID/cp-repo/$_APP_ID@$$IMG_SHA \
+      $$RELEASE_NAME
+options:
+  requestedVerifyOption: VERIFIED

--- a/application/java-app-cicd/cloudprovision.json
+++ b/application/java-app-cicd/cloudprovision.json
@@ -1,0 +1,173 @@
+{
+  "create": {
+    "steps": [
+      {
+        "id": "Inspect Values",
+        "name": "ubuntu",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "echo _APP_ID=${_APP_ID} _APP_NAME=\"${_APP_NAME}\" _REGION=${_REGION} _INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER} _INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN} _API_KEY=${_API_KEY}"
+        ]
+      },
+      {
+        "id": "clone cp-templates",
+        "name": "gcr.io/cloud-builders/git",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "git clone -b main https://github.com/gitrey/cp-templates.git"
+        ]
+      },
+      {
+        "id": "clone cp-utils",
+        "name": "gcr.io/cloud-builders/git",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "git clone -b main https://github.com/cgrant/cp-utils.git utils"
+        ]
+      },
+      {
+        "id": "createApp",
+        "name": "ubuntu",
+        "env": [
+          "APP_ID=${_APP_ID}",
+          "APP_NAME=${_APP_NAME}",
+          "REGION=${_REGION}",
+          "INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN}",
+          "INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER}",
+          "TEMPLATE_FOLDER=cp-templates/application/java-app-cicd",
+          "API_KEY=${_API_KEY}"
+        ],
+        "script": "./utils/createApp.sh"
+      },
+      {
+        "id": "createGitWebhook",
+        "name": "gcr.io/cloud-builders/gcloud",
+        "env": [
+          "PROJECT_ID=$PROJECT_ID",
+          "APP_ID=${_APP_ID}",
+          "APP_NAME=${_APP_NAME}",
+          "GIT_USER=${_INSTANCE_GIT_REPO_OWNER}",
+          "GIT_TOKEN=${_INSTANCE_GIT_REPO_TOKEN}",
+          "REGION=${_REGION}",
+          "TEMPLATE_FOLDER=cp-templates/application/java-app-cicd",
+          "API_KEY=${_API_KEY}"
+        ],
+        "script": "./utils/createWebhook.sh"
+      }
+    ]
+  },
+  "destroy": {
+    "steps": [
+      {
+        "id": "Inspect Values",
+        "name": "ubuntu",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "echo _APP_ID=${_APP_ID} _APP_NAME=${_APP_NAME} _REGION=${_REGION} _INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER} _INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN} _API_KEY=${_API_KEY}"
+        ]
+      },
+      {
+        "id": "Delete git repo",
+        "name": "curlimages/curl",
+        "args": [
+          "-L",
+          "-X",
+          "DELETE",
+          "-H",
+          "Accept: application/vnd.github+json",
+          "-H",
+          "Authorization: Bearer ${_INSTANCE_GIT_REPO_TOKEN}",
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+          "https://api.github.com/repos/${_INSTANCE_GIT_REPO_OWNER}/${_APP_ID}"
+        ]
+      },
+      {
+        "id": "Delete cloud build trigger",
+        "name": "gcr.io/google.com/cloudsdktool/cloud-sdk",
+        "entrypoint": "gcloud",
+        "args": [
+          "alpha",
+          "builds",
+          "triggers",
+          "delete",
+          "${_APP_ID}-webhook-trigger",
+          "--quiet"
+        ]
+      }
+    ]
+  },
+  "inputs": [
+    {
+      "param": "_APP_NAME",
+      "label": "Application Name",
+      "description": "Application that will be deployed.",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_REGION",
+      "label": "Application Region",
+      "description": "Where do you want to deploy the application?",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_INSTANCE_GIT_REPO_OWNER",
+      "label": "Instance GitHub Repository Owner",
+      "description": "Instance GitHub Repository Owner",
+      "type": "dropdown",
+      "required": true
+    },
+    {
+      "param": "_INSTANCE_GIT_REPO_TOKEN",
+      "label": "Instance GitHub Repository Token",
+      "description": "Instance GitHub Repository Token",
+      "type": "string",
+      "required": true,
+      "display": false
+    },
+    {
+      "param": "_API_KEY",
+      "label": "GCP API Key",
+      "description": "GCP API Key",
+      "type": "string",
+      "required": true,
+      "display": false
+    }
+  ],
+  "outputs": [
+    {
+      "param": "_SERVICE_URL",
+      "label": "Service Url",
+      "description": "Service Url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_TRIGGER_URL",
+      "label": "Cloud Build Trigger Url",
+      "description": "Cloud Build Trigger Url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_REPO_URL",
+      "label": "Repo Url",
+      "description": "Repo Url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_BUILD_URL",
+      "label": "Cloud Build Url",
+      "description": "Cloud Build Url",
+      "type": "string",
+      "required": true
+    }
+  ]
+}

--- a/application/java-app-cicd/kubernetes/base/deployment.yaml
+++ b/application/java-app-cicd/kubernetes/base/deployment.yaml
@@ -1,0 +1,44 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld
+  labels:
+    app: helloworld
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: helloworld
+  template:
+    metadata:
+      labels:
+        app: helloworld
+    spec:
+      containers:
+      - name: helloworld
+        image: helloworld
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Mi"
+          limits:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Mi"

--- a/application/java-app-cicd/kubernetes/base/kustomization.yaml
+++ b/application/java-app-cicd/kubernetes/base/kustomization.yaml
@@ -1,0 +1,19 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/application/java-app-cicd/kubernetes/base/service.yaml
+++ b/application/java-app-cicd/kubernetes/base/service.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    app: helloworld
+spec:
+  ports:
+    - port: 8080
+      name: helloworld
+  selector:
+    app: helloworld

--- a/application/java-app-cicd/kubernetes/dev/kustomization.yaml
+++ b/application/java-app-cicd/kubernetes/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/
+
+patches:
+- path: target.yaml
+  target:
+    kind: Deployment

--- a/application/java-app-cicd/kubernetes/dev/target.yaml
+++ b/application/java-app-cicd/kubernetes/dev/target.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld
+  labels:
+    app: helloworld
+spec:
+  template:
+    spec:
+      containers:
+        - name: helloworld
+          env:
+            - name: ENVIRONMENT
+              value: dev

--- a/application/java-app-cicd/pom.xml
+++ b/application/java-app-cicd/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2019 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.google</groupId>
+  <artifactId>helloworld</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!--  The parent pom defines common style checks and testing strategies for our samples.
+	Removing or replacing it should not affect the execution of the samples in anyway. -->
+
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.target>20</maven.compiler.target>
+    <maven.compiler.source>20</maven.compiler.source>
+    <spring-boot.version>3.1.2</spring-boot.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.9</version>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/application/java-app-cicd/skaffold.yaml
+++ b/application/java-app-cicd/skaffold.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skaffold/v2beta16
+kind: Config
+deploy:
+  kustomize:
+    paths:
+     - kubernetes/*
+profiles:
+- name: dev
+  deploy:
+    kustomize:
+      paths:
+        - kubernetes/dev

--- a/application/java-app-cicd/src/main/java/com/example/helloworld/HelloworldApplication.java
+++ b/application/java-app-cicd/src/main/java/com/example/helloworld/HelloworldApplication.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START cloudrun_helloworld_service]
+// [START run_helloworld_service]
+
+package com.example.helloworld;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+public class HelloworldApplication {
+
+  @Value("${NAME:World}")
+  String name;
+
+  @RestController
+  class HelloworldController {
+    @GetMapping("/")
+    String hello() {
+      return "\nHello " + name + "! 🎉\n\n";
+    }
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(HelloworldApplication.class, args);
+  }
+}
+// [END run_helloworld_service]
+// [END cloudrun_helloworld_service]

--- a/application/java-app-cicd/src/main/resources/application.properties
+++ b/application/java-app-cicd/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# [START cloudrun_helloworld_properties]
+# [START run_helloworld_properties]
+server.port=${PORT:8080}
+# [END run_helloworld_properties]
+# [END cloudrun_helloworld_properties]

--- a/application/java-app-cicd/src/test/java/com/example/helloworld/HelloworldApplicationTests.java
+++ b/application/java-app-cicd/src/test/java/com/example/helloworld/HelloworldApplicationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.helloworld;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HelloworldApplicationTests {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  public void returnsHelloWorld() throws Exception {
+    mockMvc
+        .perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("\nHello World! 🎉\n\n"));
+  }
+}

--- a/catalog.json
+++ b/catalog.json
@@ -268,5 +268,55 @@
         "type": "url"
       }
     ]
+  },
+  {
+    "id": 15,
+    "name": "Java w/ CICD",
+    "description": "Java application with CICD integration",
+    "sourceUrl": "https://github.com/gitrey/cp-templates/tree/main/application/java-app-cicd",
+    "cloudProvisionConfigUrl": "https://raw.githubusercontent.com/gitrey/cp-templates/main/application/java-app-cicd/cloudprovision.json",
+    "version": "1.0.0",
+    "tags": [
+      "java",
+      "gke",
+      "cicd"
+    ],
+    "category": "application",
+    "lastModified": "2023-09-10T11:10:04.000Z",
+    "owner": "Google Cloud Solutions Architecture Team",
+    "email": "sa-cloud-provision-templates@google.com",
+    "draft": true,
+    "metadata": [
+      {
+        "name": "Build, test, and containerize Java applications",
+        "value": "https://cloud.google.com/build/docs/building/build-containerize-java",
+        "type": "url"
+      }
+    ]
+  },
+  {
+    "id": 16,
+    "name": "Cloud Deploy Pipeline w/ GKE Target",
+    "description": "Cloud Deploy pipeline with a single GKE target (dev)",
+    "sourceUrl": "https://github.com/gitrey/cp-templates/tree/main/infra/clouddeploy-pipeline",
+    "cloudProvisionConfigUrl": "https://raw.githubusercontent.com/gitrey/cp-templates/main/infra/clouddeploy-pipeline/cloudprovision.json",
+    "version": "1.0.0",
+    "tags": [
+      "gke",
+      "cicd",
+      "pipeline"
+    ],
+    "category": "infra",
+    "lastModified": "2023-09-10T11:10:04.000Z",
+    "owner": "Google Cloud Solutions Architecture Team",
+    "email": "sa-cloud-provision-templates@google.com",
+    "draft": true,
+    "metadata": [
+      {
+        "name": "Deploy an app to GKE using Cloud Deploy",
+        "value": "https://cloud.google.com/deploy/docs/deploy-app-gke",
+        "type": "url"
+      }
+    ]
   }
 ]

--- a/infra/clouddeploy-pipeline/build/cloudbuild.yaml
+++ b/infra/clouddeploy-pipeline/build/cloudbuild.yaml
@@ -1,0 +1,51 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - '-c'
+      - |
+        IFS='/' read -a array <<< "${_REF}"
+        echo ${_REF}
+        echo 0 ${array[0]}
+        echo 1 ${array[1]}
+        echo 2 ${array[2]}
+        echo REPO=${_APP_REPO}
+        echo _SHA=${_SHA}
+        export REPO=${_APP_REPO}
+
+        echo BRANCH_NAME=${array[2]}
+        export BRANCH_NAME=${array[2]}
+
+        if ((${array[1]} == "tags")); then
+          echo "TAG " ${BRANCH_NAME}
+        elif ((${array[2]} == "main")); then
+          echo "main"
+        else
+          echo ${BRANCH_NAME}
+        fi
+        echo "git clone -b ${array[2]} ${_APP_REPO}"
+        git clone -b ${array[2]} ${_APP_REPO}
+        echo done
+    id: clone-app
+    entrypoint: bash
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: 'bash'
+    args:
+    - '-xe'
+    - -c
+    - |
+      gcloud deploy apply \
+      --region ${_REGION} \
+      --file ./${_APP_ID}/clouddeploy.yaml

--- a/infra/clouddeploy-pipeline/clouddeploy.yaml.tmpl
+++ b/infra/clouddeploy-pipeline/clouddeploy.yaml.tmpl
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: deploy.cloud.google.com/v1
+kind: DeliveryPipeline
+metadata:
+  name: ${APP_ID}
+description: ${APP_ID} with Skaffold profiles
+serialPipeline:
+ stages:
+ - targetId: dev
+   profiles:
+   - dev
+---
+apiVersion: deploy.cloud.google.com/v1
+kind: Target
+metadata:
+  name: dev
+description: Dev cluster
+gke:
+  cluster: projects/${PROJECT_ID}/locations/${REGION}/clusters/dev

--- a/infra/clouddeploy-pipeline/cloudprovision.json
+++ b/infra/clouddeploy-pipeline/cloudprovision.json
@@ -1,0 +1,196 @@
+{
+    "create": {
+      "steps": [
+        {
+          "id": "Inspect Values",
+          "name": "ubuntu",
+          "entrypoint": "bash",
+          "args": [
+            "-c",
+            "echo _APP_ID=${_APP_ID} _APP_NAME=\"${_APP_NAME}\" _REGION=${_REGION} _INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER} _INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN} _API_KEY=${_API_KEY}"
+          ]
+        },
+        {
+          "id": "clone cp-templates",
+          "name": "gcr.io/cloud-builders/git",
+          "entrypoint": "bash",
+          "args": [
+            "-c",
+            "git clone -b main https://github.com/gitrey/cp-templates.git"
+          ]
+        },
+        {
+          "id": "clone cp-utils",
+          "name": "gcr.io/cloud-builders/git",
+          "entrypoint": "bash",
+          "args": [
+            "-c",
+            "git clone -b main https://github.com/cgrant/cp-utils.git utils"
+          ]
+        },
+        {
+          "id": "createApp",
+          "name": "ubuntu",
+          "env": [
+            "PROJECT_ID=${PROJECT_ID}",
+            "APP_ID=${_APP_ID}",
+            "APP_NAME=${_APP_NAME}",
+            "REGION=${_REGION}",
+            "INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN}",
+            "INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER}",
+            "TEMPLATE_FOLDER=cp-templates/infra/clouddeploy-pipeline",
+            "API_KEY=${_API_KEY}"
+          ],
+          "script": "./utils/createApp.sh"
+        },
+        {
+          "id": "createGitWebhook",
+          "name": "gcr.io/cloud-builders/gcloud",
+          "env": [
+            "PROJECT_ID=$PROJECT_ID",
+            "APP_ID=${_APP_ID}",
+            "APP_NAME=${_APP_NAME}",
+            "GIT_USER=${_INSTANCE_GIT_REPO_OWNER}",
+            "GIT_TOKEN=${_INSTANCE_GIT_REPO_TOKEN}",
+            "REGION=${_REGION}",
+            "TEMPLATE_FOLDER=cp-templates/infra/clouddeploy-pipeline",
+            "API_KEY=${_API_KEY}"
+          ],
+          "script": "./utils/createWebhook.sh"
+        }
+      ]
+    },
+    "destroy": {
+      "steps": [
+        {
+          "id": "Inspect Values",
+          "name": "ubuntu",
+          "entrypoint": "bash",
+          "args": [
+            "-c",
+            "echo _APP_ID=${_APP_ID} _APP_NAME=${_APP_NAME} _REGION=${_REGION} _INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER} _INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN} _API_KEY=${_API_KEY}"
+          ]
+        },
+        {
+          "id": "clone repo ",
+          "name": "gcr.io/cloud-builders/git",
+          "entrypoint": "bash",
+          "args": [
+            "-c",
+            "git clone -b main https://github.com/${_INSTANCE_GIT_REPO_OWNER}/${_APP_ID} repo"
+          ]
+        },
+        {
+          "id": "Delete pipeline",
+          "name": "gcr.io/google.com/cloudsdktool/cloud-sdk",
+          "entrypoint": "gcloud",
+          "args": [
+            "deploy",
+            "delete",
+            "--file=repo/clouddeploy.yaml",
+            "--region=${_REGION}",
+            "--force",
+            "--quiet"
+          ]
+        },
+        {
+          "id": "Delete git repo",
+          "name": "curlimages/curl",
+          "args": [
+            "-L",
+            "-X",
+            "DELETE",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-H",
+            "Authorization: Bearer ${_INSTANCE_GIT_REPO_TOKEN}",
+            "-H",
+            "X-GitHub-Api-Version: 2022-11-28",
+            "https://api.github.com/repos/${_INSTANCE_GIT_REPO_OWNER}/${_APP_ID}"
+          ]
+        },
+        {
+          "id": "Delete cloud build trigger",
+          "name": "gcr.io/google.com/cloudsdktool/cloud-sdk",
+          "entrypoint": "gcloud",
+          "args": [
+            "alpha",
+            "builds",
+            "triggers",
+            "delete",
+            "${_APP_ID}-webhook-trigger",
+            "--quiet"
+          ]
+        }
+      ]
+    },
+    "inputs": [
+      {
+        "param": "_APP_NAME",
+        "label": "Application Name",
+        "description": "Application that will be deployed.",
+        "type": "string",
+        "required": true
+      },
+      {
+        "param": "_REGION",
+        "label": "Application Region",
+        "description": "Where do you want to deploy the application?",
+        "type": "string",
+        "required": true
+      },
+      {
+        "param": "_INSTANCE_GIT_REPO_OWNER",
+        "label": "Instance GitHub Repository Owner",
+        "description": "Instance GitHub Repository Owner",
+        "type": "dropdown",
+        "required": true
+      },
+      {
+        "param": "_INSTANCE_GIT_REPO_TOKEN",
+        "label": "Instance GitHub Repository Token",
+        "description": "Instance GitHub Repository Token",
+        "type": "string",
+        "required": true,
+        "display": false
+      },
+      {
+        "param": "_API_KEY",
+        "label": "GCP API Key",
+        "description": "GCP API Key",
+        "type": "string",
+        "required": true,
+        "display": false
+      }
+    ],
+    "outputs": [
+      {
+        "param": "_SERVICE_URL",
+        "label": "Service Url",
+        "description": "Service Url",
+        "type": "string",
+        "required": true
+      },
+      {
+        "param": "_TRIGGER_URL",
+        "label": "Cloud Build Trigger Url",
+        "description": "Cloud Build Trigger Url",
+        "type": "string",
+        "required": true
+      },
+      {
+        "param": "_REPO_URL",
+        "label": "Repo Url",
+        "description": "Repo Url",
+        "type": "string",
+        "required": true
+      },
+      {
+        "param": "_BUILD_URL",
+        "label": "Cloud Build Url",
+        "description": "Cloud Build Url",
+        "type": "string",
+        "required": true
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds:

- A Java app to `applications`, which incorporates CI/CD with Cloud Build and Cloud Deploy
- A Cloud Deploy pipeline to `infra`, with a single GKE target, `dev` (which must be created out-of-band)

Both of these entries in the catalog are marked as `draft` -- there are multiple potential enhancements and additions.

There is a dependency between the two entities in lieu of the linking concept of an `Environment` -- for an application named `my-java-app`, the associated pipeline must be named `my-java-app-pipeline`. Once implemented, an `Environment` will be the link between these entities.

The relevant permissions for the service account used by Cloud Build are:

```
Artifact Registry Reader
Artifact Registry Writer
Cloud Deploy Admin
Container Analysis Notes Viewer
Container Analysis Occurrences for Notes Viewer
Container Analysis Occurrences Viewer
```
