### PR TITLE
Add support for Cloud Workstations created via Infra Manager

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -318,5 +318,30 @@
         "type": "url"
       }
     ]
+  },
+  {
+    "id": 17,
+    "name": "Cloud Workstations via Infra Manager",
+    "description": "Cloud Workstations Cluster and Configuration via Infra Manager",
+    "sourceUrl": "https://github.com/gitrey/cp-templates/tree/main/infra/cloud-workstations-infra-manager",
+    "cloudProvisionConfigUrl": "https://raw.githubusercontent.com/gitrey/cp-templates/main/infra/cloud-workstations-infra-manager/cloudprovision.json",
+    "version": "1.0.0",
+    "tags": [
+      "workstations",
+      "terraform",
+      "infra manager"
+    ],
+    "category": "infra",
+    "lastModified": "2023-10-10T14:10:04.000Z",
+    "owner": "Google Cloud Solutions Architecture Team",
+    "email": "sa-cloud-provision-templates@google.com",
+    "draft": true,
+    "metadata": [
+      {
+        "name": "Cloud Workstations architecture",
+        "value": "https://cloud.google.com/workstations/docs/architecture",
+        "type": "url"
+      }
+    ]
   }
 ]

--- a/infra/cloud-workstations-infra-manager/cloudprovision.json
+++ b/infra/cloud-workstations-infra-manager/cloudprovision.json
@@ -1,0 +1,120 @@
+{
+  "create": {
+    "steps": [
+      {
+        "id": "Inspect Values",
+        "name": "ubuntu",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "echo _APP_ID=${_APP_ID} _APP_NAME=${_APP_NAME} _REGION=${_REGION} _INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER} _INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN} _API_KEY=${_API_KEY}"
+        ]
+      },
+      {
+        "id": "Clone cp-templates",
+        "name": "gcr.io/cloud-builders/git",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "git clone -b main https://github.com/gitrey/cp-templates.git"
+        ]
+      },
+      {
+        "id": "Create Cloud Workstations with Infra Manager",
+        "name": "gcr.io/google.com/cloudsdktool/cloud-sdk",
+        "entrypoint": "bash",
+        "env": [
+          "APP_ID=${_APP_ID}",
+          "APP_NAME=${_APP_NAME}",
+          "REGION=${_REGION}"
+        ],
+        "args": [
+          "-c",
+          "cd cp-templates/infra/cloud-workstations-infra-manager && ./create.sh"
+        ]
+      }
+    ]
+  },
+  "destroy": {
+    "steps": [
+      {
+        "id": "Inspect Values",
+        "name": "ubuntu",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "echo _APP_ID=${_APP_ID} _APP_NAME=${_APP_NAME} _REGION=${_REGION} _INSTANCE_GIT_REPO_OWNER=${_INSTANCE_GIT_REPO_OWNER} _INSTANCE_GIT_REPO_TOKEN=${_INSTANCE_GIT_REPO_TOKEN} _API_KEY=${_API_KEY}"
+        ]
+      },
+      {
+        "id": "Clone cp-templates",
+        "name": "gcr.io/cloud-builders/git",
+        "entrypoint": "bash",
+        "args": [
+          "-c",
+          "git clone -b main https://github.com/gitrey/cp-templates.git"
+        ]
+      },
+      {
+        "id": "Delete Cloud Workstations with Infra Manager",
+        "name": "gcr.io/google.com/cloudsdktool/cloud-sdk",
+        "entrypoint": "bash",
+        "env": [
+          "APP_ID=${_APP_ID}",
+          "APP_NAME=${_APP_NAME}",
+          "REGION=${_REGION}"
+        ],
+        "args": [
+          "-c",
+          "cd cp-templates/infra/cloud-workstations-infra-manager && ./destroy.sh"
+        ]
+      }
+    ]
+  },
+  "inputs": [
+    {
+      "param": "_APP_NAME",
+      "label": "Cluster Name",
+      "description": "Application that will be deployed.",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_REGION",
+      "label": "Cluster Region",
+      "description": "Where do you want to deploy the application?",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "param": "_SERVICE_URL",
+      "label": "Service Url",
+      "description": "Service Url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_TRIGGER_URL",
+      "label": "Cloud Build Trigger Url",
+      "description": "Cloud Build Trigger Url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_REPO_URL",
+      "label": "Repo Url",
+      "description": "Repo Url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "param": "_BUILD_URL",
+      "label": "Cloud Build Url",
+      "description": "Cloud Build Url",
+      "type": "string",
+      "required": true
+    }
+  ]
+}

--- a/infra/cloud-workstations-infra-manager/create.sh
+++ b/infra/cloud-workstations-infra-manager/create.sh
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PROJECT_ID=$(gcloud config list --format 'value(core.project)')
+export SERVICE_ACCOUNT=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")-compute@developer.gserviceaccount.com
+
+echo $SERVICE_ACCOUNT
+
+# Region for Infra Manager is hard-coded to us-central1
+gcloud infra-manager deployments apply projects/${PROJECT_ID}/locations/us-central1/deployments/${APP_ID} \
+     --service-account=projects/${PROJECT_ID}/serviceAccounts/${SERVICE_ACCOUNT} \
+     --local-source=terraform \
+     --input-values=project_id=${PROJECT_ID},region=${REGION},cluster_id=${APP_ID}

--- a/infra/cloud-workstations-infra-manager/destroy.sh
+++ b/infra/cloud-workstations-infra-manager/destroy.sh
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PROJECT_ID=$(gcloud config list --format 'value(core.project)')
+
+# Region for Infra Manager is hard-coded to us-central1
+gcloud infra-manager deployments delete projects/${PROJECT_ID}/locations/us-central1/deployments/${APP_ID}

--- a/infra/cloud-workstations-infra-manager/terraform/cluster.tf
+++ b/infra/cloud-workstations-infra-manager/terraform/cluster.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_workstations_workstation_cluster" "workstation_cluster" {
+
+  provider = google-beta
+  project  = var.project_id
+  location = var.region
+
+  workstation_cluster_id = var.cluster_id
+
+  network    = google_compute_network.workstation_cluster_network.id
+  subnetwork = google_compute_subnetwork.workstation_cluster_subnetwork.id
+
+  annotations = {
+    managed-by = "cloud-workbench"
+  }
+}

--- a/infra/cloud-workstations-infra-manager/terraform/configurations.tf
+++ b/infra/cloud-workstations-infra-manager/terraform/configurations.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_workstations_workstation_config" "workstation_configs" {
+  provider = google-beta
+  project  = var.project_id
+  location = var.region
+
+  for_each = toset(["golang", "java", "python"])
+
+  workstation_config_id  = "workstations-${each.key}-config"
+  workstation_cluster_id = google_workstations_workstation_cluster.workstation_cluster.workstation_cluster_id
+
+  idle_timeout    = "1200s"
+  running_timeout = "21600s"
+
+  annotations = {
+    managed-by = "cloud-workbench"
+  }
+
+  host {
+    gce_instance {
+      machine_type                = "e2-standard-4"
+      boot_disk_size_gb           = 35
+      disable_public_ip_addresses = false
+    }
+  }
+
+  container {
+    image = "codeoss"
+  }
+}

--- a/infra/cloud-workstations-infra-manager/terraform/network.tf
+++ b/infra/cloud-workstations-infra-manager/terraform/network.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_network" "workstation_cluster_network" {
+  name                    = "workstation-cluster-network"
+  project                 = var.project_id
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "workstation_cluster_subnetwork" {
+  name          = "workstation-cluster-subnetwork"
+  project       = var.project_id
+  ip_cidr_range = "10.0.0.0/24"
+  region        = var.region
+  network       = google_compute_network.workstation_cluster_network.name
+}

--- a/infra/cloud-workstations-infra-manager/terraform/variables.tf
+++ b/infra/cloud-workstations-infra-manager/terraform/variables.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "cluster_id" {
+  type = string
+}

--- a/infra/cloud-workstations-infra-manager/terraform/versions.tf
+++ b/infra/cloud-workstations-infra-manager/terraform/versions.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.1"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.1"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an alternative mechanism for provisioning infrastructure for Cloud Workstations (extensible to other resources) via [Infra(structure) Manager](https://cloud.google.com/infrastructure-manager/docs). In this case the default Compute SA is used by Infra Manager, though an alternative could be used instead. In the default model, the following role is required for base Infra Manager permissions:

- `Cloud Infrastructure Manager Agent`

As well as the following roles to allow the creation of the VPC network and Cloud Workstations cluster:

- `Compute Network Admin`
- `Cloud Workstations Admin`

It will also need `ActAs` permissions on itself (most commonly via `iam.serviceAccountUser`).

Note that in a similar pattern to the existing, imperative Cloud Workstations creation mechanism via the `gcloud` command, this configuration creates the cluster and the configurations, though not the workstations themselves.